### PR TITLE
Feat#socket : add STOMP-based real-time chat room view and controller

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/dev/gaau/messenger/config/WebSocketConfig.java
+++ b/src/main/java/dev/gaau/messenger/config/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package dev.gaau.messenger.config;
+
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*");
+    }
+
+}

--- a/src/main/java/dev/gaau/messenger/controller/ChatController.java
+++ b/src/main/java/dev/gaau/messenger/controller/ChatController.java
@@ -49,7 +49,7 @@ public class ChatController {
     @PostMapping("/room/{chatRoomId}")
     public String sendMessage(@PathVariable("chatRoomId") Long chatRoomId,
                               @ModelAttribute MessageRequestDto messageRequestDto) {
-        MessageDto messageDto = chatService.sendMessage(temporaryMemberId, chatRoomId, messageRequestDto);
+        MessageDto messageDto = chatService.sendMessage(messageRequestDto);
 
         return "redirect:" + chatRoomId;
     }

--- a/src/main/java/dev/gaau/messenger/controller/ChatControllerV2.java
+++ b/src/main/java/dev/gaau/messenger/controller/ChatControllerV2.java
@@ -1,0 +1,36 @@
+package dev.gaau.messenger.controller;
+
+import dev.gaau.messenger.dto.request.ChatRoomCreateRequestDto;
+import dev.gaau.messenger.dto.request.MessageRequestDto;
+import dev.gaau.messenger.dto.response.ChatRoomDto;
+import dev.gaau.messenger.dto.response.ChatRoomSummaryDto;
+import dev.gaau.messenger.dto.response.MessageDto;
+import dev.gaau.messenger.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/view/v2/chat")
+@RequiredArgsConstructor
+public class ChatControllerV2 {
+
+    private final ChatService chatService;
+
+    @GetMapping("/room/{memberId}/{chatRoomId}")
+    public String chatRoomPage(Model model,
+                               @PathVariable("memberId") Long memberId,
+                               @PathVariable("chatRoomId") Long chatRoomId) {
+
+        ChatRoomDto chatRoom = chatService.getChatRoomById(chatRoomId);
+        List<MessageDto> messages = chatService.getMessages(memberId, chatRoomId);
+
+        model.addAttribute("chatRoom", chatRoom);
+        model.addAttribute("messages", messages);
+        model.addAttribute("loggedInMemberId", memberId);
+        return "socket/room";
+    }
+}

--- a/src/main/java/dev/gaau/messenger/controller/MessageController.java
+++ b/src/main/java/dev/gaau/messenger/controller/MessageController.java
@@ -1,0 +1,27 @@
+package dev.gaau.messenger.controller;
+
+import dev.gaau.messenger.dto.request.MessageRequestDto;
+import dev.gaau.messenger.dto.response.MessageDto;
+import dev.gaau.messenger.service.ChatService;
+import jakarta.websocket.server.PathParam;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.util.HtmlUtils;
+
+@Controller
+@RequiredArgsConstructor
+public class MessageController {
+
+    private final SimpMessageSendingOperations template;
+    private final ChatService chatService;
+
+    @MessageMapping("/chat/message")
+    public void sendMessage(MessageRequestDto messageRequestDto) {
+        MessageDto message = chatService.sendMessage(messageRequestDto);
+        template.convertAndSend("/topic/chat/room/" + message.getChatRoomId(), message);
+    }
+
+}

--- a/src/main/java/dev/gaau/messenger/dto/request/MessageRequestDto.java
+++ b/src/main/java/dev/gaau/messenger/dto/request/MessageRequestDto.java
@@ -9,6 +9,8 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 public class MessageRequestDto {
+    private Long memberId;
+    private Long chatRoomId;
     private String type;
     private String contents;
 }

--- a/src/main/java/dev/gaau/messenger/service/ChatService.java
+++ b/src/main/java/dev/gaau/messenger/service/ChatService.java
@@ -81,21 +81,21 @@ public class ChatService {
     }
 
 
-    public MessageDto sendMessage(Long loggedInMemberId, Long chatRoomId, MessageRequestDto messageRequestDto) {
+    public MessageDto sendMessage(MessageRequestDto messageRequestDto) {
 
         // 1. 로그인한 사용자의 ID로 Member 엔티티 조회
-        Member loggedInMember = memberRepository.findById(loggedInMemberId).orElseThrow(
-                () -> new RuntimeException("cannot find member with id : " + loggedInMemberId)
+        Member loggedInMember = memberRepository.findById(messageRequestDto.getMemberId()).orElseThrow(
+                () -> new RuntimeException("cannot find member with id : " + messageRequestDto.getMemberId())
         );
 
         // 2. 채팅방 ID로 ChatRoom 엔티티 조회
-        ChatRoom savedChatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(
-                () -> new RuntimeException("cannot find chat room with id : " + chatRoomId)
+        ChatRoom savedChatRoom = chatRoomRepository.findById(messageRequestDto.getChatRoomId()).orElseThrow(
+                () -> new RuntimeException("cannot find chat room with id : " + messageRequestDto.getChatRoomId())
         );
 
         // 3. 로그인한 사용자가 채팅방의 participants 인지 확인
         if (!memberChatRoomRepository.existsByMemberAndChatRoom(loggedInMember,savedChatRoom)) {
-            throw new RuntimeException("Member " + loggedInMemberId + " is not the participant of Chat Room " + chatRoomId);
+            throw new RuntimeException("Member " + loggedInMember.getId() + " is not the participant of Chat Room " + savedChatRoom.getId());
         }
 
         // 4. 요청 DTO로부터 message 생성

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,7 +4,8 @@ spring.datasource.url=jdbc:mysql://${DB_URL}:${DB_PORT}/${DB_NAME}?useSSL=false&
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=true
 
 spring.sql.init.mode=always
+spring.jpa.defer-datasource-initialization=true

--- a/src/main/resources/templates/socket/room.html
+++ b/src/main/resources/templates/socket/room.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <title>채팅방</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@stomp/stompjs@7.0.0/bundles/stomp.umd.min.js"></script>
+</head>
+<body class="bg-gray-100 flex flex-col h-screen">
+
+<!-- 상단 헤더 -->
+<header class="bg-white shadow-md p-4 flex items-center">
+    <a href="/view/chat" class="text-blue-500 hover:underline mr-4">&larr; 목록으로</a>
+    <h1 class="text-xl font-semibold" th:text="${chatRoom.title}">채팅방 이름</h1>
+</header>
+
+<!-- 메시지 영역 -->
+<main id="message-list" class="flex-1 overflow-y-auto p-6 space-y-4">
+    <div th:each="msg : ${messages}">
+        <!-- 내 메시지 -->
+        <div th:if="${msg.memberId} == ${loggedInMemberId}"
+             class="max-w-xs bg-blue-500 text-white p-3 rounded-lg rounded-tr-none mr-0 mb-2 ml-auto">
+            <p th:text="${msg.contents}">내 메시지 내용</p>
+            <span class="block text-xs text-white/80 mt-1 text-right"
+                  th:text="${#temporals.format(msg.createdAt, 'HH:mm')}">13:45</span>
+        </div>
+        <!-- 상대 메시지 -->
+        <div th:if="${msg.memberId} != ${loggedInMemberId}"
+             class="max-w-xs bg-gray-200 text-gray-900 p-3 rounded-lg rounded-tl-none ml-0 mb-2">
+            <p th:text="${msg.contents}">상대 메시지 내용</p>
+            <span class="block text-xs text-gray-600 mt-1 text-right"
+                  th:text="${#temporals.format(msg.createdAt, 'HH:mm')}">13:46</span>
+        </div>
+    </div>
+</main>
+
+<!-- 입력 폼 -->
+<footer class="bg-white p-4">
+    <form class="flex items-center space-x-2">
+        <input id="new-message" type="text" name="contents" required
+               placeholder="메시지를 입력하세요"
+               class="flex-1 border border-gray-300 rounded-full px-4 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"/>
+        <input type="hidden" name = "type" value = "USER">
+        <button id = "send" type="submit"
+                class="bg-blue-600 text-white px-4 py-2 rounded-full hover:bg-blue-700 transition">
+            전송
+        </button>
+    </form>
+</footer>
+</body>
+
+<script th:inline="javascript">
+
+    var chatRoomId = [[${chatRoom.id}]];
+    var loggedInMemberId = [[${loggedInMemberId}]];
+
+    const stompClient = new StompJs.Client({
+        brokerURL: 'ws://localhost:8080/ws'
+    });
+
+    window.onload = () => {
+        connect()
+    }
+
+    stompClient.onConnect = (frame) => {
+        console.log('Connected: ' + frame);
+        stompClient.subscribe('/topic/chat/room/' + chatRoomId, (message) => {
+            var msgMemberId = JSON.parse(message.body).memberId;
+
+            if (msgMemberId === loggedInMemberId) {
+                showMyMessage(JSON.parse(message.body).contents);
+            } else {
+                showOtherMessage(JSON.parse(message.body).contents);
+            }
+        });
+    };
+
+    stompClient.onWebSocketError = (error) => {
+        console.error('Error with websocket', error);
+    };
+
+    stompClient.onStompError = (frame) => {
+        console.error('Broker reported error: ' + frame.headers['message']);
+        console.error('Additional details: ' + frame.body);
+    };
+
+    function connect() {
+        stompClient.activate();
+    }
+
+    function disconnect() {
+        stompClient.deactivate();
+        setConnected(false);
+        console.log("Disconnected");
+    }
+
+    function sendMessage() {
+        console.log("messageSent");
+        stompClient.publish({
+            destination: "/pub/chat/message",
+            body: JSON.stringify({  memberId: loggedInMemberId,
+                                    chatRoomId : chatRoomId,
+                                    type : "USER",
+                                    contents: $("#new-message").val()})
+        });
+    }
+
+    function showMyMessage(message) {
+        $("#message-list").append('<div class="max-w-xs bg-blue-500 text-white p-3 rounded-lg rounded-tr-none mr-0 mb-2 ml-auto">\n'
+            + '<p>' + message + '</p>\n'
+            + '<span class="block text-xs text-white/80 mt-1 text-right">13:46</span>\n'
+            + '</div>\n');
+    }
+
+    function showOtherMessage(message) {
+        $("#message-list").append('<div class="max-w-xs bg-gray-200 text-gray-900 p-3 rounded-lg rounded-tl-none ml-0 mb-2">\n'
+            + '<p>' + message + '</p>\n'
+            + '<span class="block text-xs text-gray-600 mt-1 text-right">13:46</span>\n'
+            + '</div>\n');
+    }
+
+    $(function () {
+        $("form").on('submit', (e) => e.preventDefault());
+        $( "#send" ).click(() => sendMessage());
+    });
+</script>
+</html>


### PR DESCRIPTION
📝 Description:
This PR introduces a new WebSocket-based real-time chat feature using STOMP. It includes both server-side and client-side components to enable users to view past messages and exchange messages in real time within a specific chat room.

🔧 Changes:
Added ChatControllerV2

Serves the chat room page

Loads chat room info and message history into the model

Added socket/room.html Thymeleaf template

Built with TailwindCSS

Connects to /ws WebSocket endpoint using STOMP

Subscribes to /topic/chat/room/{chatRoomId} to receive messages

Sends messages to /pub/chat/message

Separates UI for own messages and other users' messages

Implemented message sending and appending via jQuery and STOMP client

Initial message time formatting implemented for loaded messages

✅ How to Test:
Start the server and navigate to
/view/v2/chat/room/{memberId}/{chatRoomId}

Open two browser windows with different memberIds

Send messages from one window and confirm that they appear in real time in the other

⚠️ Notes:
WebSocket connection URL is currently hardcoded as ws://localhost:8080/ws
→ Should be externalized for deployment environments

Live messages do not yet show accurate timestamps
→ Could be improved in a future PR

